### PR TITLE
Added removeOnUse, removeTokens and removeUserTokens options and functions

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
     "hat": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "from": "hat@0.0.3"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@ const token = LoginToken.createTokenForUser(userId, [options]);
 
 `option` variable allows `removeOnUse` and `removeUserTokens` to be defined.
  - `removeOnUse`: will remove the token from the database once logged in.
- - `removeUserTokens`: will remove all other user tokens in the database before issuing a new token.
+ - `removeUserTokens`: will remove all other tokens for `userId` in the database before issuing a new token.
 
 ### Remove tokens from the database (server-only)
 
 ```js
 
 const options = {
-  allTokens: Match.optional(Boolean),
-  usedTokens: Match.optional(Boolean),
-  expiredTokens: Match.optional(Boolean)
+  allTokens: false,
+  usedTokens: false,
+  expiredTokens: false
 }
 
 LoginToken.removeTokens(options)
@@ -48,16 +48,17 @@ All options default to false, `allTokens` overrides other options.
 ```js
 
 const options = {
-  allTokens: Match.optional(Boolean),
-  usedTokens: Match.optional(Boolean),
-  expiredTokens: Match.optional(Boolean)
+  allTokens: false,
+  usedTokens: false,
+  expiredTokens: false
 }
 
-LoginToken.removeTokens(userId, options)
+LoginToken.removeUserTokens(userId, options)
 
 ```
 
-All options default to false, `allTokens` overrides other options.
+All options default to false, `allTokens` overrides other options. Same as `removeTokens`, specific
+to a single user.
 
 ### Log in...
 Go to `http://myapp.mydomain.com/some/route?authToken=<token>`

--- a/README.md
+++ b/README.md
@@ -14,8 +14,50 @@ $ meteor add dispatch:login-token
 
 ### Generate a token for a user (server-only)
 ```js
-const token = LoginToken.createTokenForUser(userId);
+
+const options = {
+  removeOnUse: false,
+  removeUserTokens: false
+}
+
+const token = LoginToken.createTokenForUser(userId, [options]);
 ```
+
+`option` variable allows `removeOnUse` and `removeUserTokens` to be defined.
+ - `removeOnUse`: will remove the token from the database once logged in.
+ - `removeUserTokens`, will remove all other user tokens in the database before issuing a new token.
+
+### Remove tokens from the database (server-only)
+
+```js
+
+const options = {
+  allTokens: Match.optional(Boolean),
+  usedTokens: Match.optional(Boolean),
+  expiredTokens: Match.optional(Boolean)
+}
+
+LoginToken.removeTokens(options)
+
+```
+
+All options default to false, `allTokens` overrides other options.
+
+### Remove user specific tokens from the database (server-only)
+
+```js
+
+const options = {
+  allTokens: Match.optional(Boolean),
+  usedTokens: Match.optional(Boolean),
+  expiredTokens: Match.optional(Boolean)
+}
+
+LoginToken.removeTokens(userId, options)
+
+```
+
+All options default to false, `allTokens` overrides other options.
 
 ### Log in...
 Go to `http://myapp.mydomain.com/some/route?authToken=<token>`
@@ -35,4 +77,3 @@ The "error" callbacks receive the error as the only argument, and the `"loggedIn
 
 ### Change expiration
 Set the token expiration by running `LoginToken.setExpiration(val)`. It is in **milliseconds**. It default to one hour (60 * 60 * 1000).
-

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ const token = LoginToken.createTokenForUser(userId, [options]);
 
 `option` variable allows `removeOnUse` and `removeUserTokens` to be defined.
  - `removeOnUse`: will remove the token from the database once logged in.
- - `removeUserTokens`, will remove all other user tokens in the database before issuing a new token.
+ - `removeUserTokens`: will remove all other user tokens in the database before issuing a new token.
 
 ### Remove tokens from the database (server-only)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-login-token
-============
+Login Token Authentication
+==========================
 
 Automatically log in a user if a valid, unexpired, single-use `authToken` is present in the URL.
 
@@ -12,7 +12,7 @@ Use at your own risk. We use it for logging in via email and SMS notifications.
 $ meteor add dispatch:login-token
 ```
 
-### Generate a token for a user (server-only)
+### Generate a token for a user *(server-only)*
 ```js
 
 const options = {
@@ -27,8 +27,7 @@ const token = LoginToken.createTokenForUser(userId, [options]);
  - `removeOnUse`: will remove the token from the database once logged in.
  - `removeUserTokens`: will remove all other tokens for `userId` in the database before issuing a new token.
 
-### Remove tokens from the database (server-only)
-
+### Remove tokens from the database *(server-only)*
 ```js
 
 const options = {
@@ -43,8 +42,7 @@ LoginToken.removeTokens(options)
 
 All options default to false, `allTokens` overrides other options.
 
-### Remove user specific tokens from the database (server-only)
-
+### Remove user specific tokens from the database *(server-only)*
 ```js
 
 const options = {
@@ -57,13 +55,13 @@ LoginToken.removeUserTokens(userId, options)
 
 ```
 
-All options default to false, `allTokens` overrides other options. Same as `removeTokens`, specific
-to a single user.
+All options default to false, `allTokens` overrides other options. Same as `removeTokens` but specific
+to a single `userId`.
 
-### Log in...
+### Log In
 Go to `http://myapp.mydomain.com/some/route?authToken=<token>`
 
-### Events/callbacks
+### Events/Callbacks
 The `LoginToken` object emits events both on the client and server. To listen to events, just use `LoginToken.on('<event name>', callback);`
 
 The events are:
@@ -76,5 +74,5 @@ The events are:
 The "error" callbacks receive the error as the only argument, and the `"loggedIn" callbacks receive the `userId` as the only argument.
 ```
 
-### Change expiration
+### Changing Expiration
 Set the token expiration by running `LoginToken.setExpiration(val)`. It is in **milliseconds**. It default to one hour (60 * 60 * 1000).

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dispatch:login-token',
-  version: '0.1.2',
+  version: '0.1.32',
   summary: 'Log the user in if they have the correct single-use token ' +
     'in the URL',
   git: 'https://github.com/DispatchMe/meteor-login-token',

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dispatch:login-token',
-  version: '0.1.32',
+  version: '0.1.3',
   summary: 'Log the user in if they have the correct single-use token ' +
     'in the URL',
   git: 'https://github.com/DispatchMe/meteor-login-token',

--- a/server.js
+++ b/server.js
@@ -69,8 +69,8 @@ Accounts.registerLoginHandler(function (loginRequest) {
 LoginToken.createTokenForUser = function (userId, options = {}) {
 
   check(options, {
-    removeUserTokens: Match.optional(Boolean),
-    removeOnUse: Match.optional(Boolean)
+    removeUserTokens: Match.Optional(Boolean),
+    removeOnUse: Match.Optional(Boolean)
   })
 
   // aaronthorp: remove any old login tokens for user, active, expired or used
@@ -95,13 +95,13 @@ LoginToken.createTokenForUser = function (userId, options = {}) {
 LoginToken.removeTokens = function (options = {}) {
 
   check(options, {
-    allTokens: Match.optional(Boolean),
-    usedTokens: Match.optional(Boolean),
-    expiredTokens: Match.optional(Boolean),
+    allTokens: Match.Optional(Boolean),
+    usedTokens: Match.Optional(Boolean),
+    expiredTokens: Match.Optional(Boolean),
   })
 
   if (options.allTokens) {
-    LoginToken.TokenCollection.remove()
+    LoginToken.TokenCollection.remove({})
     return
   }
 
@@ -119,9 +119,9 @@ LoginToken.removeTokens = function (options = {}) {
 LoginToken.removeUserTokens = function(userId, options) {
 
   check(options, {
-    allTokens: Match.optional(Boolean),
-    usedTokens: Match.optional(Boolean),
-    expiredTokens: Match.optional(Boolean),
+    allTokens: Match.Optional(Boolean),
+    usedTokens: Match.Optional(Boolean),
+    expiredTokens: Match.Optional(Boolean),
   })
 
   if (options.allTokens) {

--- a/server.js
+++ b/server.js
@@ -43,15 +43,19 @@ Accounts.registerLoginHandler(function (loginRequest) {
     throw new Meteor.Error('Token has expired');
   }
 
-  // Update it to used
-  LoginToken.TokenCollection.update(doc._id, {
-    $set: {
-      used: true,
-      usedAt: new Date(),
-    },
-
-  });
-
+  // aaronthorp: remove once token is used if flag set
+  if (doc.removeOnUse) {
+    // remove the token
+    LoginToken.TokenCollection.remove(doc._id)
+  } else {
+    // Update it to used
+    LoginToken.TokenCollection.update(doc._id, {
+      $set: {
+        used: true,
+        usedAt: new Date(),
+      },
+    });
+  }
   const userId = doc.userId.toString();
 
   // Emit events for any listeners
@@ -62,13 +66,76 @@ Accounts.registerLoginHandler(function (loginRequest) {
   };
 });
 
-LoginToken.createTokenForUser = function (userId) {
+LoginToken.createTokenForUser = function (userId, options = {}) {
+
+  check(options, {
+    removeUserTokens: Match.optional(Boolean),
+    removeOnUse: Match.optional(Boolean)
+  })
+
+  // aaronthorp: remove any old login tokens for user, active, expired or used
+  //             before generating a new token.
+  if (removeUserTokens) {
+    LoginToken.removeUserTokens(userId, {allTokens: true})
+  }
+
   const token = hat(256);
   LoginToken.TokenCollection.insert({
     userId: userId,
     expiresAt: new Date(Date.now() + expiration),
     token: token,
+    // aaronthorp: flag the token to be removed on use if set in options
+    removeOnUse: !!removeOnUse,
   });
 
   return token;
 };
+
+// aaronthorp: remove old login tokens for user, also remove used tokens if true
+LoginToken.removeTokens = function (options = {}) {
+
+  check(options, {
+    allTokens: Match.optional(Boolean),
+    usedTokens: Match.optional(Boolean),
+    expiredTokens: Match.optional(Boolean),
+  })
+
+  if (options.allTokens) {
+    LoginToken.TokenCollection.remove()
+    return
+  }
+
+  if (options.expiredTokens) {
+    const now = Date.now();
+    LoginToken.TokenCollection.remove({expiresAt: {$lt: now}})
+  }
+
+  if (options.usedTokens) {
+    LoginToken.TokenCollection.remove({used: true})
+  }
+
+}
+
+LoginToken.removeUserTokens = function(userId, options) {
+
+  check(options, {
+    allTokens: Match.optional(Boolean),
+    usedTokens: Match.optional(Boolean),
+    expiredTokens: Match.optional(Boolean),
+  })
+
+  if (options.allTokens) {
+    LoginToken.TokenCollection.remove({userId: userId})
+    return
+  }
+
+  if (options.expiredTokens) {
+    const now = Date.now();
+    LoginToken.TokenCollection.remove({userId: userId, expiresAt: {$lt: now}})
+  }
+
+  if (options.usedTokens) {
+    LoginToken.TokenCollection.remove({userId: userId, used: true})
+  }
+
+}

--- a/server.js
+++ b/server.js
@@ -72,7 +72,7 @@ LoginToken.createTokenForUser = function (userId, options = {}) {
     removeOnUse: Match.Optional(Boolean)
   })
 
-  if (removeUserTokens) {
+  if (options.removeUserTokens) {
     LoginToken.removeUserTokens(userId, {allTokens: true})
   }
 

--- a/server.js
+++ b/server.js
@@ -81,7 +81,7 @@ LoginToken.createTokenForUser = function (userId, options = {}) {
     userId: userId,
     expiresAt: new Date(Date.now() + expiration),
     token: token,
-    removeOnUse: !!removeOnUse,
+    removeOnUse: !!options.removeOnUse,
   });
 
   return token;

--- a/server.js
+++ b/server.js
@@ -43,7 +43,6 @@ Accounts.registerLoginHandler(function (loginRequest) {
     throw new Meteor.Error('Token has expired');
   }
 
-  // aaronthorp: remove once token is used if flag set
   if (doc.removeOnUse) {
     // remove the token
     LoginToken.TokenCollection.remove(doc._id)
@@ -73,8 +72,6 @@ LoginToken.createTokenForUser = function (userId, options = {}) {
     removeOnUse: Match.Optional(Boolean)
   })
 
-  // aaronthorp: remove any old login tokens for user, active, expired or used
-  //             before generating a new token.
   if (removeUserTokens) {
     LoginToken.removeUserTokens(userId, {allTokens: true})
   }
@@ -84,14 +81,12 @@ LoginToken.createTokenForUser = function (userId, options = {}) {
     userId: userId,
     expiresAt: new Date(Date.now() + expiration),
     token: token,
-    // aaronthorp: flag the token to be removed on use if set in options
     removeOnUse: !!removeOnUse,
   });
 
   return token;
 };
 
-// aaronthorp: remove old login tokens for user, also remove used tokens if true
 LoginToken.removeTokens = function (options = {}) {
 
   check(options, {


### PR DESCRIPTION
Added `removeOnUse` and `removeUserTokens` flags to `createUserToken` function to allow login to remove token instead of flagging used as well as removing all existing tokens for `userId` before issuing a new one.

Also created `removeTokens` and `removeUserTokens` functions to allow flushing of used/expired/all tokens via cron or as required.

Updated readme with examples and additional functions.