### PR TITLE
Add option to use a token x times

### DIFF
--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
     "hat": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/hat/-/hat-0.0.3.tgz",
+      "from": "hat@0.0.3"
     }
   }
 }

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'dispatch:login-token',
-  version: '0.1.2',
+  version: '0.2.0',
   summary: 'Log the user in if they have the correct single-use token ' +
     'in the URL',
   git: 'https://github.com/DispatchMe/meteor-login-token',

--- a/server.js
+++ b/server.js
@@ -72,6 +72,7 @@ Accounts.registerLoginHandler(function(loginRequest) {
 });
 
 LoginToken.createTokenForUser = function(userId) {
+  if (!userId) throw new Meteor.Error('No userId supplied to LoginToken.createTokenForUser(userId)');
   const token = hat(256);
   LoginToken.TokenCollection.insert({
     userId,

--- a/server.js
+++ b/server.js
@@ -56,6 +56,8 @@ Accounts.registerLoginHandler(function(loginRequest) {
         usedAt: new Date(),
       },
     });
+  } else {
+    LoginToken.TokenCollection.update(doc._id, { $inc: { numberOfUses: 1 } });
   }
 
 

--- a/server.js
+++ b/server.js
@@ -64,7 +64,12 @@ Accounts.registerLoginHandler(function(loginRequest) {
   const userId = doc.userId.toString();
 
   // Emit events for any listeners
-  LoginToken.emit('loggedInServer', userId);
+  try {
+    LoginToken.emit('loggedInServer', userId);
+  } catch (e) {
+    console.error('Error in loggedInServer event', e);
+  }
+
 
   return {
     userId,
@@ -76,6 +81,7 @@ LoginToken.createTokenForUser = function(userId) {
   const token = hat(256);
   LoginToken.TokenCollection.insert({
     userId,
+    used: false,
     expiresAt: new Date(Date.now() + expiration),
     token,
     maxNumberOfUses,

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 LoginToken.TokenCollection = new Mongo.Collection('LoginToken_tokens');
 
-Meteor.startup(function () {
+Meteor.startup(function() {
   LoginToken.TokenCollection._ensureIndex({
     token: 1,
   });
@@ -8,16 +8,21 @@ Meteor.startup(function () {
 
 // Default expiration is 1 hour
 let expiration = 60 * 60 * 1000;
+let maxNumberOfUses = 1;
 
-LoginToken.setExpiration = function (exp) {
+LoginToken.setExpiration = function(exp) {
   expiration = exp;
+};
+
+LoginToken.setMaxNumberOfUses = function(number) {
+  maxNumberOfUses = number;
 };
 
 // Hat can generate unique tokens
 const hat = Npm.require('hat');
 
 // Login with just a token
-Accounts.registerLoginHandler(function (loginRequest) {
+Accounts.registerLoginHandler(function(loginRequest) {
   // Is there an auth token? If not, just let Meteor handle it. Call it dispatch_authToken in case there's another
   // library that uses authToken
   if (!loginRequest || !loginRequest.dispatch_authToken) {
@@ -44,13 +49,15 @@ Accounts.registerLoginHandler(function (loginRequest) {
   }
 
   // Update it to used
-  LoginToken.TokenCollection.update(doc._id, {
-    $set: {
-      used: true,
-      usedAt: new Date(),
-    },
+  if (doc.maxNumberOfUses === doc.numberOfUses) {
+    LoginToken.TokenCollection.update(doc._id, {
+      $set: {
+        used: true,
+        usedAt: new Date(),
+      },
+    });
+  }
 
-  });
 
   const userId = doc.userId.toString();
 
@@ -58,16 +65,18 @@ Accounts.registerLoginHandler(function (loginRequest) {
   LoginToken.emit('loggedInServer', userId);
 
   return {
-    userId: userId,
+    userId,
   };
 });
 
-LoginToken.createTokenForUser = function (userId) {
+LoginToken.createTokenForUser = function(userId) {
   const token = hat(256);
   LoginToken.TokenCollection.insert({
-    userId: userId,
+    userId,
     expiresAt: new Date(Date.now() + expiration),
-    token: token,
+    token,
+    maxNumberOfUses,
+    numberOfUses: 0,
   });
 
   return token;


### PR DESCRIPTION
Dear Dispatch Team,

we need an option to use the tokens more then one time. Some users press the link on one device and expect it to also login when they try to open the same link on another device. I think a lot of people use more then one device.

The new code should also work for old tokens in the database and does not change the default behaviour of working only one time.

I will add a clean Readme if you are interested to merge this! Any feedback?